### PR TITLE
Fixed 2digit 12hour time appearing with a zero.

### DIFF
--- a/modules/clock.lua
+++ b/modules/clock.lua
@@ -50,9 +50,11 @@ clockFrame:SetScript('OnUpdate', function(self, e)
 				clockText:SetText(hour..":"..minu)
 				amText:SetText("")	
 			else
-				if hour > 12 then 
+				if hour > 12 then
 					hour = hour - 12
-					hour = ("0"..hour)
+					if hour < 10 then
+						hour = ("0"..hour)
+					end
 					AmPmTimeText = "PM"
 				else 
 					AmPmTimeText = "AM"


### PR DESCRIPTION
For example, it used to appear like this: 09:12, 010:12, 011:12, 12:12
But with this very simple thing it appears like this: 09:12, 10:12, 11:12, 12:12